### PR TITLE
FIX Add $Form variable to page layout template

### DIFF
--- a/templates/Layout/Page.ss
+++ b/templates/Layout/Page.ss
@@ -2,6 +2,7 @@
     <h1 class="page__title">$Title</h1>
     $Content
     $ElementalArea
+    $Form
 </div>
 <% if $Menu($PageLevel).count > 1 && $PageLevel > 1 %>
     <% include Sidebar %>


### PR DESCRIPTION
This is the same template the simple theme had it in: https://github.com/silverstripe/silverstripe-simple/blob/3/templates/Layout/Page.ss

## Issue

- https://github.com/silverstripe/startup-theme/issues/26