### PR TITLE
FIX Use correct variable for date

### DIFF
--- a/templates/Includes/Footer.ss
+++ b/templates/Includes/Footer.ss
@@ -3,7 +3,7 @@
         <nav aria-label="Footer">
             <ul class="footer-menu">
                 <li class="footer-menu__item footer-menu__item--copyright">
-                    &copy; $CurrentDatetime.Format("y") $SiteConfig.Title
+                    &copy; $Now.Format("y") $SiteConfig.Title
                 </li>
                 <% loop $Menu(1) %>
                     <li class="footer-menu__item">


### PR DESCRIPTION
Issue https://github.com/silverstripe/startup-theme/issues/29

Comes from [DBDateTime::get_template_global_variables()](https://github.com/silverstripe/silverstripe-framework/blob/6/src/ORM/FieldType/DBDatetime.php#L324)