### PR TITLE
FIX Ensure sidebar menu squashes on thinner widths

### DIFF
--- a/css/page.css
+++ b/css/page.css
@@ -24,8 +24,9 @@
     width: 100%;
 
     @media (min-width: 992px) {
-        margin-top: 0;
+        margin: 0 4rem;
         width: 27rem;
+        flex-shrink: 1;
     }
 }
 


### PR DESCRIPTION
Needs 40px margin either side, and should squash if needed.

Used to be:

![image](https://github.com/user-attachments/assets/62da2e1c-6d3f-4ba9-8cb4-8d7b6a66d430)

Now:

![image](https://github.com/user-attachments/assets/cb7dab51-ac9e-43e5-9622-1dda5c5de00c)

## Issue

- https://github.com/silverstripe/startup-theme/issues/24