### PR TITLE
SDEMO-766 #18 Page content contained width

### DIFF
--- a/css/page.css
+++ b/css/page.css
@@ -10,13 +10,7 @@
 }
 
 .page__content {
-    width: 100%;
-}
-
-.page__content--with-sidebar {
-    @media (min-width: 992px) {
-        width: 76rem;
-    }
+    max-width: 76rem;
 }
 
 .page-menu {


### PR DESCRIPTION
Ensure page content maxes out at 760px wide for accessibility/ readability

## Issue

- https://github.com/silverstripe/startup-theme/issues/18