### PR TITLE
#25 SDEMO-783 Revised sidebar

### DIFF
--- a/css/page.css
+++ b/css/page.css
@@ -60,7 +60,7 @@
 
 .page-menu__list-item {
     margin: 0;
-  padding-left: 1.5rem;
+    padding-left: 1.5rem;
 }
 
 .page-menu__list-item--current {

--- a/css/page.css
+++ b/css/page.css
@@ -41,7 +41,6 @@
     border-bottom: 0.1rem solid var(--color-line-grey);
     padding-bottom: 2.5rem;
     display: grid;
-    font-size: 1.4rem;
     gap: 1.7rem;
     list-style: none;
 
@@ -61,13 +60,14 @@
 
 .page-menu__list-item {
     margin: 0;
+  padding-left: 1.5rem;
 }
 
 .page-menu__list-item--current {
     font-weight: var(--font-weight-bold);
+    border-left: 0.2rem solid var(--color-charcoal);
 }
 
 .page-menu__list-item--child {
     font-weight: var(--font-weight-base);
-    margin-left: 1.75em;
 }

--- a/templates/Includes/LevelOneSidebar.ss
+++ b/templates/Includes/LevelOneSidebar.ss
@@ -1,3 +1,5 @@
+<%-- This sidebar template is used when a page is top-level (1) in the sitetree and has
+     child pages. See layout/Page.ss for the display conditions. --%>
 <aside class="page-menu">
     <nav class="page-menu__nav" aria-labelledby="page-menu-heading">
         <h2 id="page-menu-heading" class="h5 page-menu__heading">$Title</h2>

--- a/templates/Includes/LevelOneSidebar.ss
+++ b/templates/Includes/LevelOneSidebar.ss
@@ -1,0 +1,10 @@
+<aside class="page-menu">
+    <nav class="page-menu__nav" aria-labelledby="page-menu-heading">
+        <h2 id="page-menu-heading" class="h5 page-menu__heading">$Title</h2>
+        <ul class="page-menu__list">
+            <% loop $Children %>
+                <li class="page-menu__list-item"><a href="$Link">$Title</a></li>
+            <% end_loop %>
+        </ul>
+    </nav>
+</aside>

--- a/templates/Includes/Sidebar.ss
+++ b/templates/Includes/Sidebar.ss
@@ -1,3 +1,6 @@
+<%-- This sidebar template is used when a page is lower than top-level (> 1) in the sitetree and has
+     sibling pages (same parent & level). If the current page has children, links to those pages are
+     rendered as well. See layout/Page.ss for the display conditions. --%>
 <aside class="page-menu">
     <nav class="page-menu__nav" aria-labelledby="page-menu-heading">
         <h2 id="page-menu-heading" class="h5 page-menu__heading">

--- a/templates/Includes/Sidebar.ss
+++ b/templates/Includes/Sidebar.ss
@@ -1,7 +1,7 @@
 <aside class="page-menu">
     <nav class="page-menu__nav" aria-labelledby="page-menu-heading">
         <h2 id="page-menu-heading" class="h5 page-menu__heading">
-            <a href="$Parent.Link" class="page-menu__heading-link">$Parent.Title</a>
+            <% if $PageLevel == 1 %>Navigation<% else %>$Parent.Title<% end_if %>
         </h2>
         <ul class="page-menu__list">
         <% loop $Menu($PageLevel) %>

--- a/templates/Includes/Sidebar.ss
+++ b/templates/Includes/Sidebar.ss
@@ -1,7 +1,7 @@
 <aside class="page-menu">
     <nav class="page-menu__nav" aria-labelledby="page-menu-heading">
         <h2 id="page-menu-heading" class="h5 page-menu__heading">
-            <% if $PageLevel == 1 %>Navigation<% else %>$Parent.Title<% end_if %>
+            <a href="$Parent.Link" class="page-menu__heading-link">$Parent.Title</a>
         </h2>
         <ul class="page-menu__list">
         <% loop $Menu($PageLevel) %>

--- a/templates/Layout/Page.ss
+++ b/templates/Layout/Page.ss
@@ -1,9 +1,9 @@
-<div class="page__content <% if $Menu($PageLevel).count > 1 && $PageLevel > 1 %>page__content--with-sidebar<% end_if %>">
+<div class="page__content <% if $Menu($PageLevel).count > 1 %>page__content--with-sidebar<% end_if %>">
     <h1 class="page__title">$Title</h1>
     $Content
     $ElementalArea
     $Form
 </div>
-<% if $Menu($PageLevel).count > 1 && $PageLevel > 1 %>
+<% if $Menu($PageLevel).count > 1 %>
     <% include Sidebar %>
 <% end_if %>

--- a/templates/Layout/Page.ss
+++ b/templates/Layout/Page.ss
@@ -6,6 +6,6 @@
 </div>
 <% if $PageLevel == 1 && $Children %>
     <% include LevelOneSidebar %>
-<% else_if $Menu($PageLevel).count > 1 %>
+<% else_if $PageLevel > 1 && $Menu($PageLevel).count > 1 %>
     <% include Sidebar %>
 <% end_if %>

--- a/templates/Layout/Page.ss
+++ b/templates/Layout/Page.ss
@@ -1,9 +1,11 @@
-<div class="page__content <% if $Menu($PageLevel).count > 1 %>page__content--with-sidebar<% end_if %>">
+<div class="page__content">
     <h1 class="page__title">$Title</h1>
     $Content
     $ElementalArea
     $Form
 </div>
-<% if $Menu($PageLevel).count > 1 %>
+<% if $PageLevel == 1 && $Children %>
+    <% include LevelOneSidebar %>
+<% else_if $Menu($PageLevel).count > 1 %>
     <% include Sidebar %>
 <% end_if %>


### PR DESCRIPTION
This pull request relates to [issue 25](https://github.com/silverstripe/startup-theme/issues/25)

From the discussion there and further discussions with James the criteria for the sidebar is:

- If page is top level, and has children ~ show the sidebar with the children, with current page as non-link heading
- if page is deeper than top level and has siblings ~ show the sidebar with siblings next to the active page. The parent page will be be a link heading. This menu will also loop children of the active page (if there are any).
- If neither of those conditions are met, menu is hidden.

I tried a few things and I think the cleanest approach was to create an alternate sidebar template and conditionally render the Includes files based on the above logic. All of the inline logic got pretty messy otherwise with if statements all over the place in one sidebar template. Im interested if you can think of a better approach