### PR TITLE
SDEMO-767 re-add home link in crumbs

### DIFF
--- a/templates/BreadcrumbsTemplate.ss
+++ b/templates/BreadcrumbsTemplate.ss
@@ -1,18 +1,16 @@
 <nav class="breadcrumbs" aria-label="Breadcrumbs">
     <ol class="breadcrumbs__list">
         <li class="breadcrumbs__list-item">
-            <a href="$BaseURL">Home</a>
+            <a href="$BaseURL"><%t StartupTheme.BREADCRUMBS_HOME 'Home' %></a>
             <span class="breadcrumbs__list-delimiter" aria-hidden="true">/</span>
         </li>
-        <% if $Pages %>
-            <% loop $Pages %>
-                <% if not $IsLast %>
-                    <li class="breadcrumbs__list-item">
-                        <% if not $Up.Unlinked %><a href="$Link"><% end_if %>$MenuTitle.XML<% if not Up.Unlinked %></a><% end_if %>
-                        <span class="breadcrumbs__list-delimiter" aria-hidden="true">/</span>
-                    </li>
-                <% end_if %>
-            <% end_loop %>
-        <% end_if %>
+        <% loop $Pages %>
+            <% if not $IsLast && not $isHomePage %>
+                <li class="breadcrumbs__list-item">
+                    <% if not $Up.Unlinked %><a href="$Link"><% end_if %>$MenuTitle.XML<% if not Up.Unlinked %></a><% end_if %>
+                    <span class="breadcrumbs__list-delimiter" aria-hidden="true">/</span>
+                </li>
+            <% end_if %>
+        <% end_loop %>
     </ol>
 </nav>

--- a/templates/BreadcrumbsTemplate.ss
+++ b/templates/BreadcrumbsTemplate.ss
@@ -1,6 +1,10 @@
-<% if $Pages %>
-    <nav class="breadcrumbs" aria-label="Breadcrumbs">
-        <ol class="breadcrumbs__list">
+<nav class="breadcrumbs" aria-label="Breadcrumbs">
+    <ol class="breadcrumbs__list">
+        <li class="breadcrumbs__list-item">
+            <a href="$BaseURL">Home</a>
+            <span class="breadcrumbs__list-delimiter" aria-hidden="true">/</span>
+        </li>
+        <% if $Pages %>
             <% loop $Pages %>
                 <% if not $IsLast %>
                     <li class="breadcrumbs__list-item">
@@ -9,6 +13,6 @@
                     </li>
                 <% end_if %>
             <% end_loop %>
-        </ol>
-    </nav>
-<% end_if %>
+        <% end_if %>
+    </ol>
+</nav>


### PR DESCRIPTION
This pull request addresses issue  [https://github.com/silverstripe/startup-theme/issues/19](https://github.com/silverstripe/startup-theme/issues/19)

Link to homepage to be always included in BreadcrumbsTemplate.ss