### PR TITLE
SDEMO-774 Mobile menu to match design

### DIFF
--- a/css/accordion.css
+++ b/css/accordion.css
@@ -18,9 +18,13 @@
 }
 
 [data-accordion-flip] {
+  svg {
     transition: var(--transition-default);
+  }
 }
 
 .accordion__item.is-active [data-accordion-flip] {
+  svg {
     rotate: -180deg;
+  }
 }

--- a/css/accordion.css
+++ b/css/accordion.css
@@ -18,13 +18,9 @@
 }
 
 [data-accordion-flip] {
-  svg {
-    transition: var(--transition-default);
-  }
+  transition: var(--transition-default);
 }
 
 .accordion__item.is-active [data-accordion-flip] {
-  svg {
-    rotate: -180deg;
-  }
+  rotate: -180deg;
 }

--- a/css/header.css
+++ b/css/header.css
@@ -250,17 +250,29 @@
     position: relative;
 }
 
+.mobile-submenu__item:last-of-type {
+  padding-bottom: 2.5rem;
+}
+
 .mobile-menu__link,
 .mobile-submenu__link {
     display: block;
     text-decoration: none;
-    padding: 2rem 1rem;
     height: 100%;
     width: 100%;
 
     &:hover {
-        background: var(--color-line-grey);
+        text-decoration: underline;
     }
+}
+
+.mobile-menu__link {
+  padding: 2rem 1rem 2rem 0;
+  font-weight: var(--font-weight-medium);
+}
+
+.mobile-submenu__link {
+  padding: 1rem;
 }
 
 .mobile-submenu {
@@ -273,10 +285,6 @@
     width: 100%;
 }
 
-.mobile-submenu__link {
-    padding-left: 3rem;
-}
-
 .mobile-submenu-chevron,
 .submenu-chevron {
     cursor: pointer;
@@ -287,7 +295,8 @@
     position: absolute;
     right: 0;
     top: 1rem;
-    padding: 1rem;
+    padding: 1rem 2rem;
+    border-left: 0.1rem var(--color-line-grey) solid;
 
     &:hover {
         color: var(--color-grey);

--- a/templates/Includes/Header.ss
+++ b/templates/Includes/Header.ss
@@ -56,8 +56,8 @@
                         <a href="$Link" id="{$URLSegment}-mobile-submenu-link" class="mobile-menu__link"
                         >$MenuTitle</a>
                         <% if $Children %>
-                            <button class="mobile-submenu-chevron accordion__toggle" type="button" aria-label="Open $MenuTitle submenu" aria-expanded="false" aria-controls="{$URLSegment}-mobile-submenu" data-accordion-flip>
-                                <svg width="11" height="8" viewBox="0 0 11 8" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                            <button class="mobile-submenu-chevron accordion__toggle" type="button" aria-label="Open $MenuTitle submenu" aria-expanded="false" aria-controls="{$URLSegment}-mobile-submenu">
+                                <svg width="11" height="8" viewBox="0 0 11 8" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" data-accordion-flip>
                                     <path d="M0 1.88973L1.29663 0.5L5.50183 5.08612L9.70337 0.5L11 1.88973L5.50183 7.86607L0 1.88973Z" fill="currentcolor"/>
                                 </svg>
                             </button>


### PR DESCRIPTION
This addresses issue 22: https://github.com/silverstripe/startup-theme/issues/22

It was mainly spacing that needed tweaking to match the designs. Also added a chevron border and adjusted rotation targeting as to not rotate said border on active. 

Designs:
https://www.figma.com/design/x1egzaHVafuFXtvyuJCgGf/Silverstripe-Startup-Theme?node-id=271-12&p=f&t=YPFx4Ph19pan4SAl-0

<img width="1063" height="514" alt="Screenshot 2025-08-07 at 1 23 12 PM" src="https://github.com/user-attachments/assets/54719e72-7593-48da-813c-02b3855ddc13" />



