### PR TITLE
FIX Don't let navigator overlap with nav

### DIFF
--- a/css/header.css
+++ b/css/header.css
@@ -128,7 +128,7 @@
     margin-right: -1rem;
     padding: 2rem 1rem;
     position: relative;
-    z-index: 30;
+    z-index: 40;
 
     @media (min-width: 992px) {
         display: none;
@@ -213,6 +213,7 @@
     visibility: hidden;
     white-space: nowrap;
     width: 0;
+    z-index: 30;
 }
 
 .mobile-menu-is-active .nav--mobile {
@@ -242,7 +243,6 @@
 .mobile-menu {
     border-bottom: 0.1rem var(--color-line-grey) solid;
     color: var(--color-charcoal);
-    z-index: 30;
 }
 
 .mobile-menu__item {

--- a/css/silverstripe-navigator.css
+++ b/css/silverstripe-navigator.css
@@ -4,6 +4,10 @@ div#SilverStripeNavigator {
     border-top: 0;
 }
 
-#SilverStripeNavigatorMessage {
+div#SilverStripeNavigatorMessage {
+    top: 10rem;
     background: #000A;
+    /* one less than mobile nav */
+    z-index: 29;
+    pointer-events: none;
 }


### PR DESCRIPTION
- Moves the navigator stage indicator below the main nav bar
- Adjust z-index so that opening the mobile nav hides the stage indicator
- Removes pointer events from the indicator in case it overlaps with an interactive element when scrolling down the page

## Issue

- https://github.com/silverstripe/startup-theme/issues/44