### PR TITLE
FIX h2 size 28px, h2 margin adjustments, navigation hover

### DIFF
--- a/css/header.css
+++ b/css/header.css
@@ -73,6 +73,10 @@
     transition: var(--transition-color);
 }
 
+.menu__link:hover {
+    color: var(--color-white-70);
+}
+
 .menu__link--current,
 .menu__link--section {
     border-color: var(--color-white);

--- a/css/typography.css
+++ b/css/typography.css
@@ -62,15 +62,21 @@ h1, .h1 {
 }
 
 h2, .h2 {
-    font-size: 3.2rem;
+    font-size: 2.8rem;
     font-weight: var(--font-weight-extrabold);
     line-height: 1.2;
+    margin: 1.5em 0 0.5em;
+}
+
+h2:first-of-type, .h2:first-of-type {
+    margin: 0.75em 0 0.5em;
 }
 
 h3, .h3 {
     font-size: 2.2rem;
     font-weight: var(--font-weight-bold);
     line-height: 1.3;
+    margin: 1em 0 0.5em;
 }
 
 h4, .h4 {
@@ -85,8 +91,8 @@ h5, .h5 {
     line-height: 1.3;
 }
 
-h2, h3, h4, h5, h6,
-.h2, .h3, .h4, .h5, .h6 {
+h4, h5, h6,
+.h4, .h5, .h6 {
     margin: 0.75em 0 0.5em;
 }
 

--- a/css/typography.css
+++ b/css/typography.css
@@ -61,22 +61,23 @@ h1, .h1 {
     }
 }
 
+h2, h3, h4, h5, h6,
+.h2, .h3, .h4, .h5, .h6 {
+  margin: 0.75em 0 0.5em;
+}
+
 h2, .h2 {
     font-size: 2.8rem;
     font-weight: var(--font-weight-extrabold);
     line-height: 1.2;
-    margin: 1.5em 0 0.5em;
-}
-
-h2:first-of-type, .h2:first-of-type {
-    margin: 0.75em 0 0.5em;
+    margin-top: 1.3em;
 }
 
 h3, .h3 {
     font-size: 2.2rem;
     font-weight: var(--font-weight-bold);
     line-height: 1.3;
-    margin: 1em 0 0.5em;
+    margin-top: 1em;
 }
 
 h4, .h4 {
@@ -89,11 +90,6 @@ h5, .h5 {
     font-size: 1.8rem;
     font-weight: var(--font-weight-bold);
     line-height: 1.3;
-}
-
-h4, h5, h6,
-.h4, .h5, .h6 {
-    margin: 0.75em 0 0.5em;
 }
 
 /* Text */


### PR DESCRIPTION
This PR addresses issues https://github.com/silverstripe/startup-theme/issues/23 and https://github.com/silverstripe/startup-theme/issues/41

Margin and font sizes adjusted for h2, and opacity on main nav hover